### PR TITLE
Add error handling for missing GoogleWS accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [1.1.2] - 05-02-2026
+
+### Changed
+- Updated account update to retrieve account information when there are no updates so account data is not cleared.
+
 ## [1.1.1] - 16-06-2025
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [1.1.2] - 05-02-2026
+## [1.1.2] - 06-02-2026
 
 ### Changed
 - Updated account update to retrieve account information when there are no updates so account data is not cleared.

--- a/update.ps1
+++ b/update.ps1
@@ -390,6 +390,14 @@ try {
 
         'NotFound' {
             Write-Information "GoogleWS account: [$($actionContext.References.Account)] could not be found, possibly indicating that it may have been deleted"
+            $splatUpdateParams = @{
+                    Uri         = "https://www.googleapis.com/admin/directory/v1/users/$($actionContext.References.Account)"
+                    Method      = 'GET'
+                    Headers     = $headers
+                    ContentType = 'application/json;charset=utf-8'
+                }
+            $updatedAccountGoogle = Invoke-RestMethod @splatUpdateParams
+            $outputContext.Data = $updatedAccountGoogle | ConvertTo-HelloIDAccountObject
             $outputContext.Success = $false
             $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = "GoogleWS account with accountReference: [$($actionContext.References.Account)] could not be found, possibly indicating that it may have been deleted"

--- a/update.ps1
+++ b/update.ps1
@@ -379,8 +379,8 @@ try {
 
         'NoChanges' {
             Write-Information "No changes to GoogleWS account with accountReference: [$($actionContext.References.Account)]"
-
             $outputContext.Success = $true
+            $outputContext.Data = $correlatedAccountGoogle | ConvertTo-HelloIDAccountObject
             $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = 'No changes will be made to the account during enforcement'
                     IsError = $false
@@ -390,14 +390,7 @@ try {
 
         'NotFound' {
             Write-Information "GoogleWS account: [$($actionContext.References.Account)] could not be found, possibly indicating that it may have been deleted"
-            $splatUpdateParams = @{
-                    Uri         = "https://www.googleapis.com/admin/directory/v1/users/$($actionContext.References.Account)"
-                    Method      = 'GET'
-                    Headers     = $headers
-                    ContentType = 'application/json;charset=utf-8'
-                }
-            $updatedAccountGoogle = Invoke-RestMethod @splatUpdateParams
-            $outputContext.Data = $updatedAccountGoogle | ConvertTo-HelloIDAccountObject
+
             $outputContext.Success = $false
             $outputContext.AuditLogs.Add([PSCustomObject]@{
                     Message = "GoogleWS account with accountReference: [$($actionContext.References.Account)] could not be found, possibly indicating that it may have been deleted"


### PR DESCRIPTION
Retrieve user on no changes so the account data is not cleared

This change does require a call to retrieve the user on every update request. It could be modified to use the previous account data but it is thought to be better to have the most current information rather than "hoping" it's correct.